### PR TITLE
Fix typo in the withdrawn date

### DIFF
--- a/srfi-198.html
+++ b/srfi-198.html
@@ -55,7 +55,7 @@ by John Cowan, Lassi Kortela, and Harold Ancell
   <li>Draft #2 published: 2020-06-24</li>
   <li>Draft #3 published: 2020-07-18</li>
   <li>Draft #4 published: 2020-08-17</li>
-  <li>Withdrawn: 2019-09-12
+  <li>Withdrawn: 2020-09-12
     <p>editor's summary of reasons for withdrawal: The authors
       disagreed on the specifics of the representation.  (See
       <a href="https://srfi-email.schemers.org/srfi-198">email


### PR DESCRIPTION
This is already withdrawn, but there's an apparent typo in the withdrawn date.